### PR TITLE
Fix SVG positioning

### DIFF
--- a/adaptive-icon.js
+++ b/adaptive-icon.js
@@ -13,6 +13,10 @@
                     contain: layout;
                 }
 
+                :host svg {
+                    display:block;
+                }
+
                 :host([mask="circle"]) .wrapper {
                     clip-path: url(#circle);
                 }
@@ -100,7 +104,7 @@
         }
 
         connectedCallback() {
-            // Firefox pls 😭
+            // Firefox pls 
             if (window.ShadyCSS) {
                 window.ShadyCSS.styleElement(this);
             }
@@ -119,7 +123,7 @@
         }
     }
 
-    // Firefox pls 😭
+    // Firefox pls 
     if (window.ShadyCSS) {
         window.ShadyCSS.prepareTemplate(template, AdaptiveIcon.is);
     }


### PR DESCRIPTION
By default SVGs are 'display:inline' this takes up ~20px pushing the wrapper down and outside the element slightly.
Changing this to 'display:block' means it takes up no space and the icons align correctly